### PR TITLE
add swiped-events and support touch scroll

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -252,6 +252,9 @@
    position: relative;
    opacity: 1; 
  }
+ .home_bg.pointer-event-none {
+   pointer-events: none;
+ }
 
  canvas {
   position: absolute;

--- a/index-liang.html
+++ b/index-liang.html
@@ -135,6 +135,7 @@
 </div>
 <!-- partial -->
   <script src='https://cdnjs.cloudflare.com/ajax/libs/gsap/2.0.2/TweenMax.min.js'></script>
+  <script src="https://cdn.jsdelivr.net/npm/swiped-events@1.1.4/src/swiped-events.min.js"></script>
 <script src='https://cdnjs.cloudflare.com/ajax/libs/three.js/99/three.min.js'></script><script  src="js/script-liang.js"></script>
 
 </body>

--- a/index.html
+++ b/index.html
@@ -140,7 +140,9 @@
 </div> -->
 <!-- partial -->
   <script src='https://cdnjs.cloudflare.com/ajax/libs/gsap/2.0.2/TweenMax.min.js'></script>
-<script src='https://cdnjs.cloudflare.com/ajax/libs/three.js/99/three.min.js'></script><script  src="js/script-liang.js"></script>
+  <script src='https://cdnjs.cloudflare.com/ajax/libs/three.js/99/three.min.js'></script>
+  <script src="https://cdn.jsdelivr.net/npm/swiped-events@1.1.4/src/swiped-events.min.js"></script>
+  <script src="js/script-liang.js"></script>
 
 </body>
 </html>

--- a/js/onespicy.js
+++ b/js/onespicy.js
@@ -30,3 +30,8 @@ var images = [
 
     
   });
+
+  var homeBg = document.querySelector('.home_bg');
+  homeBg.addEventListener('touchstart', function(){
+    homeBg.classList.add('pointer-event-none');
+  });

--- a/js/script-liang.js
+++ b/js/script-liang.js
@@ -329,6 +329,7 @@ class Slider {
 
   listeners() {
     window.addEventListener('wheel', this.nextSlide, { passive: true });
+    document.addEventListener('swiped', this.nextSlide)
   }
 
   render() {

--- a/js/script.js
+++ b/js/script.js
@@ -30,3 +30,8 @@ var images = [
 
     
   });
+
+  var homeBg = document.querySelector('.home_bg');
+  homeBg.addEventListener('touchstart', function(){
+    homeBg.classList.add('pointer-event-none');
+  });


### PR DESCRIPTION
* 在 `index.html` / `index-liang.html`，透過 [swiped-events](https://github.com/john-doherty/swiped-events) 捲到下一個項目
* 在 `index-works.html` / `onespicy.html`，收到 [touchstart](https://developer.mozilla.org/en-US/docs/Web/Events/touchstart) 時，表示裝置有支援觸控，讓個 `.home_bg` 對於觸控/滑鼠事件透明化，使之可以捲動